### PR TITLE
Add CLI configuration via argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ Simply execute the script with Python:
 python domain.py
 ```
 
+You can override several settings using command line options. Example:
+
+```bash
+python domain.py --num-candidates 500 --max-label-len 3 \
+  --top-tld-count 100 --html-out mydomains.html
+```
+
+Available options:
+
+- `--num-candidates` – number of random labels to generate (default 2500)
+- `--max-label-len` – maximum length of each label (default 4)
+- `--top-tld-count` – how many top TLDs to combine with labels (default 200)
+- `--html-out` – path to the generated HTML table
+- `--jsonl-file` – path to the JSONL results file
+- `--sorted-file` – path to the JSONL file with all combinations
+- `--log-file` – path to the log file
+
 The process may take a while as it scores thousands of potential domains and
 queries DNS. Progress information is printed to the console and recorded in
 `domain_scanner.log`.


### PR DESCRIPTION
## Summary
- add argparse-based argument parsing in `domain.py`
- expose options for candidate counts, label length, TLD count and output paths
- document new CLI options in README

## Testing
- `python -m py_compile domain.py`
- `python domain.py --help | head -n 20`
- `python domain.py --num-candidates 1 --max-label-len 1 --top-tld-count 1 --html-out out.html --jsonl-file test_results.jsonl --sorted-file test_sorted.jsonl --log-file test.log >/tmp/test_run.log && tail -n 20 /tmp/test_run.log`

------
https://chatgpt.com/codex/tasks/task_e_6862dc0b0ad4832a987c266c5d67ecb7