### PR TITLE
Add unit tests for core logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ queries DNS. Progress information is printed to the console and recorded in
 
 Running the script multiple times will append new findings to
 `results.jsonl` and update `domains.html`.
+
+## Running tests
+
+Install pytest and run the suite from the repository root:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,31 @@
+import random
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import domain
+
+
+def test_is_pronounceable():
+    assert domain.is_pronounceable("abc")
+    assert domain.is_pronounceable("ae")
+    assert not domain.is_pronounceable("bcdf")
+    assert not domain.is_pronounceable("abccd")
+
+
+def test_estimate_price():
+    assert domain.estimate_price("com") == 12
+    assert domain.estimate_price("io") == 35
+    assert domain.estimate_price("xyz") == 15
+    assert domain.estimate_price("abcdef") == 8
+
+
+def test_generate_labels():
+    random.seed(0)
+    labels = domain.generate_labels(5)
+    assert len(labels) == 5
+    assert len(set(labels)) == len(labels)
+    for lbl in labels:
+        assert domain.is_pronounceable(lbl)
+        assert 1 <= len(lbl) <= domain.MAX_LABEL_LEN


### PR DESCRIPTION
## Summary
- add pytest-based tests for helper functions
- document running the tests in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e3c2cc84832aa140e45802a37a7a