### PR TITLE
Refactor domain finder into class-based workflow

### DIFF
--- a/domain.py
+++ b/domain.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-import os
 import socket
-import subprocess
 import random
 import requests
 import time
@@ -28,6 +26,213 @@ SORTED_LIST_FILE = 'sorted_domains.jsonl'
 throttle = 0.05  # pause mellem DNS-tjek
 
 
+class DomainFinder:
+    """Encapsulate state for the domain finding workflow."""
+
+    def __init__(
+        self,
+        num_candidates: int = NUM_CANDIDATES,
+        max_label_len: int = MAX_LABEL_LEN,
+        top_tld_count: int = TOP_TLD_COUNT,
+        html_out: str = HTML_OUT,
+        jsonl_file: str = JSONL_FILE,
+        sorted_list_file: str = SORTED_LIST_FILE,
+        log_file: str = LOG_FILE,
+        pause: float = throttle,
+    ) -> None:
+        self.num_candidates = num_candidates
+        self.max_label_len = max_label_len
+        self.top_tld_count = top_tld_count
+        self.html_out = html_out
+        self.jsonl_file = jsonl_file
+        self.sorted_list_file = sorted_list_file
+        self.log_file = log_file
+        self.throttle = pause
+
+        self.processed: set[tuple[str, str]] = set()
+        self.found: list[dict] = []
+
+        self.pytrends = TrendReq(hl='en-US', tz=360)
+        self.session = requests.Session()
+        retries = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            respect_retry_after_header=True,
+        )
+        self.session.mount('https://', HTTPAdapter(max_retries=retries))
+
+    def fetch_tlds(self, retries: int = 3) -> list[str]:
+        """Fetch a list of preferred TLDs from IANA."""
+        for attempt in range(retries):
+            try:
+                resp = self.session.get(
+                    'https://data.iana.org/TLD/tlds-alpha-by-domain.txt',
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                tlds = [l.lower() for l in resp.text.splitlines() if l and not l.startswith('#')]
+                ascii_tlds = [t for t in tlds if t.isascii() and t.isalpha()]
+                top = sorted(ascii_tlds, key=len)[: self.top_tld_count]
+                logging.info(f"Valgt {len(top)} vestlige, ASCII-only TLD'er")
+                return top
+            except requests.RequestException as e:
+                logging.error(f"Forsøg {attempt + 1} på at hente TLDs fejlede: {e}")
+                if attempt < retries - 1:
+                    time.sleep(1)
+        return []
+
+
+    # --- State helpers --- #
+    def load_progress(self) -> None:
+        """Load processed domains from disk into memory."""
+        try:
+            with open(self.jsonl_file, 'r') as f:
+                for line in f:
+                    rec = json.loads(line)
+                    self.processed.add((rec['name'], rec['tld']))
+                    self.found.append(rec)
+            logging.info(
+                f"Indlæste {len(self.found)} gemte domæner fra {self.jsonl_file}"
+            )
+        except FileNotFoundError:
+            logging.info("Ingen tidligere data. Starter forfra.")
+
+    def save_record(self, rec: dict) -> None:
+        """Append a domain record to the JSONL log file."""
+        with open(self.jsonl_file, 'a') as f:
+            f.write(json.dumps(rec) + '\n')
+
+    def save_sorted_list(self, sorted_list: list[dict]) -> None:
+        """Write the sorted candidate list to disk."""
+        with open(self.sorted_list_file, 'w') as f:
+            for r in sorted_list:
+                f.write(json.dumps(r) + '\n')
+        logging.info(f"Gemte sorteret liste til {self.sorted_list_file}")
+
+    def write_html(self, results: list[dict]) -> None:
+        """Generate and write HTML output for available domains."""
+        rows = ''.join(
+            f"<tr><td>{r['name']}</td><td>{r['tld']}</td><td>{r['score']}</td>"
+            f"<td>{r['price']}</td><td>{r['ngram']:.2f}</td>"
+            f"<td>{r['volume']}</td><td>{r['auto']}</td></tr>\n"
+            for r in results
+        )
+        html = f"""<!DOCTYPE html>
+<html lang='da'><head><meta charset='UTF-8'>
+<link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
+<link rel='stylesheet' href='https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css'>
+<title>Valgte Domæner</title></head><body><div class='container py-3'>
+<h2>Tilgængelige Domæner</h2>
+<table id='domains' class='table table-striped'>
+<thead><tr><th>Navn</th><th>TLD</th><th>Score</th><th>Pris</th><th>n-gram</th><th>Volumen</th><th>Autocomplete</th></tr></thead>
+<tbody>{rows}</tbody></table></div>
+<script src='https://code.jquery.com/jquery-3.6.0.min.js'></script>
+<script src='https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js'></script>
+<script src='https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js'></script>
+<script>$(document).ready(()=>$('#domains').DataTable({pageLength:10}));</script>
+</body></html>"""
+        with open(self.html_out, 'w') as f:
+            f.write(html)
+
+    def graceful_exit(self, signum, frame) -> None:
+        """Handle SIGINT by saving HTML output and exiting."""
+        logging.info('Afslutter og gemmer HTML...')
+        self.write_html(self.found)
+        sys.exit(0)
+
+    def run(self) -> None:
+        """Execute the main domain finder workflow."""
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s %(levelname)s: %(message)s',
+            handlers=[
+                logging.FileHandler(self.log_file),
+                logging.StreamHandler(sys.stdout),
+            ],
+        )
+
+        signal.signal(signal.SIGINT, self.graceful_exit)
+
+        self.load_progress()
+        tlds = self.fetch_tlds()
+        labels = generate_labels(self.num_candidates, self.max_label_len)
+
+        logging.info(f"Starter beregning af metrics for {len(labels)} labels")
+        label_stats = {}
+        for lbl in tqdm(labels, desc='Label metrics', unit='label'):
+            label_stats[lbl] = {
+                'ngram': ngram_score(lbl),
+                'volume': search_volume(lbl, self.pytrends),
+                'auto': autocomplete_count(lbl, self.session),
+                'length_s': (self.max_label_len - len(lbl) + 1) / self.max_label_len,
+            }
+        logging.info("Færdig med label metrics")
+
+        tld_prices = {t: estimate_price(t) for t in tlds}
+
+        total = len(labels) * len(tlds)
+        logging.info(f"Starter bygning af {total} kombinationer")
+        raw = []
+        for lbl in tqdm(labels, desc='Bygger rå', unit='label'):
+            stats = label_stats[lbl]
+            for tld in tlds:
+                raw.append(
+                    {
+                        'name': lbl,
+                        'tld': tld,
+                        'price': tld_prices[tld],
+                        'ngram': stats['ngram'],
+                        'volume': stats['volume'],
+                        'auto': stats['auto'],
+                        'length_s': stats['length_s'],
+                        'idx': len(raw),
+                    }
+                )
+        logging.info(f"Datagrundlag bygget: {len(raw)} kombinationer")
+
+        logging.info("Starter parallel scoring...")
+        pn = normalize([r['price'] for r in raw])
+        nn = normalize([r['ngram'] for r in raw])
+        vn = normalize([r['volume'] for r in raw])
+        an = normalize([r['auto'] for r in raw])
+        with Pool(processes=cpu_count()) as pool:
+            args = [(r, pn, nn, vn, an) for r in raw]
+            for idx, score in tqdm(
+                pool.imap_unordered(compute_score, args),
+                total=len(raw),
+                desc='Scoring',
+                unit='item',
+            ):
+                raw[idx]['score'] = score
+        logging.info("Parallel scoring færdig")
+
+        logging.info("Starter sortering af datagrundlag...")
+        start_sort = time.time()
+        raw.sort(key=lambda x: x['score'], reverse=True)
+        logging.info(
+            f"Sortering færdig på {time.time() - start_sort:.2f} sekunder"
+        )
+        self.save_sorted_list(raw)
+
+        logging.info("Starter DNS-scanning af sorteret liste...")
+        for r in tqdm(raw, desc='DNS-scanning', unit='domæne'):
+            key = (r['name'], r['tld'])
+            if key in self.processed:
+                continue
+            domain = f"{r['name']}.{r['tld']}"
+            if dns_available(domain):
+                rec = r.copy()
+                self.found.append(rec)
+                self.processed.add(key)
+                self.save_record(rec)
+                self.write_html(self.found)
+                logging.info(f"Fundet ledigt: {domain} Score: {r['score']}")
+            time.sleep(self.throttle)
+        logging.info("Scanning færdig.")
+
+
+
 def parse_args():
     """Parse command-line arguments.
 
@@ -51,31 +256,12 @@ def parse_args():
                         help='path to log file')
     return parser.parse_args()
 
-# Checkpointing og fundne domæner
-processed = set()
-found = []
+
+# Checkpointing og fundne domæner holdes nu i klasseinstanser
 
 # Opsæt logging konfigureres i main()
 
-# Ctrl-C håndtering
-def graceful_exit(signum, frame):
-    """Handle SIGINT by saving HTML output and exiting.
-
-    Args:
-        signum (int): Signal number.
-        frame (FrameType): Current stack frame.
-    """
-    logging.info('Afslutter og gemmer HTML...')
-    write_html(found)
-    sys.exit(0)
-
-# HTTP-session med backoff
-pytrends = TrendReq(hl='en-US', tz=360)
-session = requests.Session()
-retries = Retry(total=5, backoff_factor=1,
-                status_forcelist=[429, 500, 502, 503, 504],
-                respect_retry_after_header=True)
-session.mount('https://', HTTPAdapter(max_retries=retries))
+# Pris-estimater (USD)
 
 # Pris-estimater (USD)
 PRICE_OVERRIDES = {'com': 12, 'net': 10, 'io': 35, 'co': 30,
@@ -84,56 +270,6 @@ PRICE_OVERRIDES = {'com': 12, 'net': 10, 'io': 35, 'co': 30,
 
 # --- Hjælpefunktioner --- #
 
-def load_progress():
-    """Load processed domains from disk into memory.
-
-    Returns:
-        None
-    """
-    try:
-        with open(JSONL_FILE, 'r') as f:
-            for line in f:
-                rec = json.loads(line)
-                processed.add((rec['name'], rec['tld']))
-                found.append(rec)
-        logging.info(f"Indlæste {len(found)} gemte domæner fra {JSONL_FILE}")
-    except FileNotFoundError:
-        logging.info("Ingen tidligere data. Starter forfra.")
-
-
-def save_record(rec):
-    """Append a domain record to the JSONL log file.
-
-    Args:
-        rec (dict): Record to persist.
-    """
-    with open(JSONL_FILE, 'a') as f:
-        f.write(json.dumps(rec) + '\n')
-
-
-def fetch_tlds(retries: int = 3):
-    """Fetch a list of preferred TLDs from IANA.
-
-    Args:
-        retries (int): How many attempts to try before giving up.
-
-    Returns:
-        list[str]: Filtered list of top TLDs or empty list on failure.
-    """
-    for attempt in range(retries):
-        try:
-            resp = session.get('https://data.iana.org/TLD/tlds-alpha-by-domain.txt', timeout=10)
-            resp.raise_for_status()
-            tlds = [l.lower() for l in resp.text.splitlines() if l and not l.startswith('#')]
-            ascii_tlds = [t for t in tlds if t.isascii() and t.isalpha()]
-            top = sorted(ascii_tlds, key=len)[:TOP_TLD_COUNT]
-            logging.info(f"Valgt {len(top)} vestlige, ASCII-only TLD'er")
-            return top
-        except requests.RequestException as e:
-            logging.error(f"Forsøg {attempt + 1} på at hente TLDs fejlede: {e}")
-            if attempt < retries - 1:
-                time.sleep(1)
-    return []
 
 
 def is_pronounceable(s):
@@ -180,7 +316,7 @@ def ngram_score(label):
     return zipf_frequency(label, 'en')
 
 
-def search_volume(label, retries: int = 3):
+def search_volume(label, pytrends_obj=None, retries: int = 3):
     """Fetch Google Trends search volume for a label.
 
     Args:
@@ -192,8 +328,9 @@ def search_volume(label, retries: int = 3):
     """
     for attempt in range(retries):
         try:
-            pytrends.build_payload([label], timeframe='now 7-d')
-            df = pytrends.interest_over_time()
+            pt = pytrends_obj or TrendReq(hl='en-US', tz=360)
+            pt.build_payload([label], timeframe='now 7-d')
+            df = pt.interest_over_time()
             return int(df[label].max()) if not df.empty else 0
         except Exception as e:
             logging.error(f"Google Trends fejl for '{label}' (forsøg {attempt + 1}): {e}")
@@ -202,7 +339,7 @@ def search_volume(label, retries: int = 3):
     return 0
 
 
-def autocomplete_count(label, retries: int = 3):
+def autocomplete_count(label, session_obj=None, retries: int = 3):
     """Get the number of Google autocomplete suggestions for a label.
 
     Args:
@@ -214,7 +351,8 @@ def autocomplete_count(label, retries: int = 3):
     """
     for attempt in range(retries):
         try:
-            r = session.get('https://suggestqueries.google.com/complete/search',
+            sess = session_obj or requests.Session()
+            r = sess.get('https://suggestqueries.google.com/complete/search',
                             params={'client': 'firefox', 'q': label}, timeout=3)
             r.raise_for_status()
             return len(r.json()[1])
@@ -225,7 +363,7 @@ def autocomplete_count(label, retries: int = 3):
     return 0
 
 
-def generate_labels(n):
+def generate_labels(n, max_label_len: int = MAX_LABEL_LEN):
     """Generate a set of random pronounceable labels.
 
     Args:
@@ -239,7 +377,7 @@ def generate_labels(n):
     logging.info(f"Starter generering af {n} labels")
     for _ in tqdm(range(n), desc='Labels genereret', unit='label'):
         while True:
-            length = random.randint(1, MAX_LABEL_LEN)
+            length = random.randint(1, max_label_len)
             cand = ''.join(random.choice(letters) for _ in range(length))
             if is_pronounceable(cand) and cand not in labels:
                 labels.add(cand)
@@ -277,45 +415,6 @@ def dns_available(domain):
         return True
 
 
-def save_sorted_list(sorted_list):
-    """Write the sorted candidate list to disk.
-
-    Args:
-        sorted_list (list[dict]): Domains with scores.
-    """
-    with open(SORTED_LIST_FILE, 'w') as f:
-        for r in sorted_list:
-            f.write(json.dumps(r) + '\n')
-    logging.info(f"Gemte sorteret liste til {SORTED_LIST_FILE}")
-
-
-def write_html(results):
-    """Generate and write HTML output for available domains.
-
-    Args:
-        results (list[dict]): Records of available domains.
-    """
-    rows = ''.join(
-        f"<tr><td>{r['name']}</td><td>{r['tld']}</td><td>{r['score']}</td><td>{r['price']}</td>"
-        f"<td>{r['ngram']:.2f}</td><td>{r['volume']}</td><td>{r['auto']}</td></tr>\n"
-        for r in results
-    )
-    html = f"""<!DOCTYPE html>
-<html lang='da'><head><meta charset='UTF-8'>
-<link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
-<link rel='stylesheet' href='https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css'>
-<title>Valgte Domæner</title></head><body><div class='container py-3'>
-<h2>Tilgængelige Domæner</h2>
-<table id='domains' class='table table-striped'>
-<thead><tr><th>Navn</th><th>TLD</th><th>Score</th><th>Pris</th><th>n-gram</th><th>Volumen</th><th>Autocomplete</th></tr></thead>
-<tbody>{rows}</tbody></table></div>
-<script src='https://code.jquery.com/jquery-3.6.0.min.js'></script>
-<script src='https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js'></script>
-<script src='https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js'></script>
-<script>$(document).ready(()=>$('#domains').DataTable({pageLength:10}));</script>
-</body></html>"""
-    with open(HTML_OUT, 'w') as f:
-        f.write(html)
 
 # --- Score funktion for multiprocessing --- #
 def compute_score(args):
@@ -340,108 +439,18 @@ def compute_score(args):
 
 # --- Hovedprogram --- #
 def main():
-    """Entry point for running the domain finder.
-
-    Returns:
-        None
-    """
+    """Entry point for running the domain finder."""
     args = parse_args()
-
-    global NUM_CANDIDATES, MAX_LABEL_LEN, TOP_TLD_COUNT
-    global HTML_OUT, JSONL_FILE, LOG_FILE, SORTED_LIST_FILE
-
-    NUM_CANDIDATES = args.num_candidates
-    MAX_LABEL_LEN = args.max_label_len
-    TOP_TLD_COUNT = args.top_tld_count
-    HTML_OUT = args.html_out
-    JSONL_FILE = args.jsonl_file
-    LOG_FILE = args.log_file
-    SORTED_LIST_FILE = args.sorted_file
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s %(levelname)s: %(message)s',
-        handlers=[
-            logging.FileHandler(LOG_FILE),
-            logging.StreamHandler(sys.stdout)
-        ]
+    finder = DomainFinder(
+        num_candidates=args.num_candidates,
+        max_label_len=args.max_label_len,
+        top_tld_count=args.top_tld_count,
+        html_out=args.html_out,
+        jsonl_file=args.jsonl_file,
+        sorted_list_file=args.sorted_file,
+        log_file=args.log_file,
     )
-
-    signal.signal(signal.SIGINT, graceful_exit)
-
-    load_progress()
-    tlds = fetch_tlds()
-    labels = generate_labels(NUM_CANDIDATES)
-
-    # Beregn label metrics
-    logging.info(f"Starter beregning af metrics for {len(labels)} labels")
-    label_stats = {}
-    for lbl in tqdm(labels, desc='Label metrics', unit='label'):
-        label_stats[lbl] = {
-            'ngram': ngram_score(lbl),
-            'volume': search_volume(lbl),
-            'auto': autocomplete_count(lbl),
-            'length_s': (MAX_LABEL_LEN - len(lbl) + 1) / MAX_LABEL_LEN
-        }
-    logging.info("Færdig med label metrics")
-
-    # TLD priser
-    tld_prices = {t: estimate_price(t) for t in tlds}
-
-    # Byg rå liste
-    total = len(labels) * len(tlds)
-    logging.info(f"Starter bygning af {total} kombinationer")
-    raw = []
-    for lbl in tqdm(labels, desc='Bygger rå', unit='label'):
-        stats = label_stats[lbl]
-        for tld in tlds:
-            raw.append({
-                'name': lbl,
-                'tld': tld,
-                'price': tld_prices[tld],
-                'ngram': stats['ngram'],
-                'volume': stats['volume'],
-                'auto': stats['auto'],
-                'length_s': stats['length_s'],
-                'idx': len(raw)
-            })
-    logging.info(f"Datagrundlag bygget: {len(raw)} kombinationer")
-
-    # Parallel scoring
-    logging.info("Starter parallel scoring...")
-    pn = normalize([r['price'] for r in raw])
-    nn = normalize([r['ngram'] for r in raw])
-    vn = normalize([r['volume'] for r in raw])
-    an = normalize([r['auto'] for r in raw])
-    with Pool(processes=cpu_count()) as pool:
-        args = [(r, pn, nn, vn, an) for r in raw]
-        for idx, score in tqdm(pool.imap_unordered(compute_score, args), total=len(raw), desc='Scoring', unit='item'):
-            raw[idx]['score'] = score
-    logging.info("Parallel scoring færdig")
-
-    # Sort og gem
-    logging.info("Starter sortering af datagrundlag...")
-    start_sort = time.time()
-    raw.sort(key=lambda x: x['score'], reverse=True)
-    logging.info(f"Sortering færdig på {time.time() - start_sort:.2f} sekunder")
-    save_sorted_list(raw)
-
-    # DNS-scanning
-    logging.info("Starter DNS-scanning af sorteret liste...")
-    for r in tqdm(raw, desc='DNS-scanning', unit='domæne'):
-        key = (r['name'], r['tld'])
-        if key in processed:
-            continue
-        domain = f"{r['name']}.{r['tld']}"
-        if dns_available(domain):
-            rec = r.copy()
-            found.append(rec)
-            processed.add(key)
-            save_record(rec)
-            write_html(found)
-            logging.info(f"Fundet ledigt: {domain} Score: {r['score']}")
-        time.sleep(throttle)
-    logging.info("Scanning færdig.")
+    finder.run()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- encapsulate workflow state in new `DomainFinder` class
- pass config instead of relying on globals
- update helper functions to allow injectable dependencies
- simplify `main` to instantiate and run the class

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e85283f8832a8083535aced0623d