### PR TITLE
Add asyncio-based Google Trends lookup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pytrends
 wordfreq
 tqdm
+aiohttp


### PR DESCRIPTION
## Summary
- make `search_volume` async using `aiohttp`
- concurrently fetch search volume for all labels
- execute `DomainFinder.run` inside an event loop
- include aiohttp in requirements

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862eea13a10832ab79ead4e256016e9