### PR TITLE
Add metrics caching for domain finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Available options:
 - `--log-file` – path to the log file
 - `--tld-cache-file` – path to the cached TLD list
 - `--tld-cache-age` – maximum age of the cache in seconds
+- `--metrics-cache-file` – path to the cached metrics file
 - `--force-refresh` – ignore cache and fetch TLDs again
 - `--dns-batch-size` – number of concurrent DNS lookups per batch
 


### PR DESCRIPTION
## Summary
- cache label metrics to avoid redundant network calls
- expose `--metrics-cache-file` CLI option
- document new option
- test search volume and autocomplete caching

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862f27e5e70832aa87fac99d4ff91d4