### PR TITLE
Introduce Candidate dataclass

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -104,3 +104,12 @@ def test_autocomplete_cache(monkeypatch):
     res2 = asyncio.run(domain.gather_autocomplete_counts(["abc"], cache))
     assert res2 == {"abc": 7}
 
+
+def test_candidate_serialization_roundtrip():
+    cand = domain.Candidate("foo", "com", 10, 1.0, 2, 3, 0.5, 0)
+    cand.score = 4.2
+    data = domain.candidate_to_dict(cand)
+    new = domain.candidate_from_dict(data)
+    assert new == cand
+    assert hasattr(new, "score") and new.score == cand.score
+


### PR DESCRIPTION
## Summary
- add `Candidate` dataclass and helpers
- store domain candidates as `Candidate` objects during workflow
- update scoring, serialization and HTML output
- extend tests for `Candidate` round‑trip

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f4a84384832aa1d5ffa6ba201aa7