### PR TITLE
Use heap for top domain candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Available options:
 - `--metrics-cache-file` – path to the cached metrics file
 - `--force-refresh` – ignore cache and fetch TLDs again
 - `--dns-batch-size` – number of concurrent DNS lookups per batch
+- `--queue-size` – how many top-scoring combinations to retain before scanning
 
 The process may take a while as it scores thousands of potential domains and
 queries DNS. Progress information is printed to the console and recorded in


### PR DESCRIPTION
## Summary
- limit in-memory candidates with a priority queue
- compute scores in batches and push to queue
- expose `--queue-size` option

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f851b19c832ab6fa6327df08338c