### PR TITLE
Introduce Config dataclass

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -40,7 +40,8 @@ def test_generate_labels_deterministic():
 
 def test_fetch_tlds_cached(tmp_path):
     cache = tmp_path / "tlds.json"
-    df = domain.DomainFinder(top_tld_count=2, tld_cache_file=str(cache))
+    cfg = domain.Config(top_tld_count=2, tld_cache_file=str(cache))
+    df = domain.DomainFinder(cfg)
     fake_resp = Mock()
     fake_resp.text = "COM\nNET\n"
     fake_resp.raise_for_status = Mock()
@@ -58,7 +59,8 @@ def test_fetch_tlds_cached(tmp_path):
 def test_fetch_tlds_cache_expired(tmp_path):
     cache = tmp_path / "tlds.json"
     cache.write_text(json.dumps({'timestamp': time.time() - 100, 'tlds': ["com"]}))
-    df = domain.DomainFinder(tld_cache_file=str(cache), tld_cache_age=1)
+    cfg = domain.Config(tld_cache_file=str(cache), tld_cache_age=1)
+    df = domain.DomainFinder(cfg)
     fake_resp = Mock()
     fake_resp.text = "COM\n"
     fake_resp.raise_for_status = Mock()


### PR DESCRIPTION
## Summary
- add `Config` dataclass and use it for defaults
- pass configuration object to `DomainFinder`
- update argument parsing and entrypoint
- adjust tests for new API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863565cfd04832a8a75ed64a19f0d10