### PR TITLE
Throttle search volume lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Available options:
 - `--dns-batch-size` – number of concurrent DNS lookups per batch
 - `--queue-size` – how many top-scoring combinations to retain before scanning
 - `--flush-interval` – seconds between HTML updates
+- `--trends-concurrency` – max concurrent Google Trends requests
 
 The process may take a while as it scores thousands of potential domains and
 queries DNS. Progress information is printed to the console and recorded in


### PR DESCRIPTION
## Summary
- add `trends_concurrency` configuration option
- use an `asyncio.Semaphore` in `gather_search_volumes`
- wire the limit through CLI flags and DomainFinder

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686358072448832ab845d6a23aa139ff