### PR TITLE
Add async improvements and concurrency options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ log for further processing.
 
 ## Prerequisites
 
-* Python 3.8 or later
+* Python 3.11
 * Network access to fetch TLD data and Google trends information
 
 Install required Python packages using:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-requests
-pytrends
-wordfreq
-tqdm
-aiohttp
+aiohttp==3.9.3
+aiodns==3.0.0
+pytrends==4.9.2
+wordfreq==2.5.1
+tqdm==4.66.2
+jinja2==3.1.2

--- a/style.css
+++ b/style.css
@@ -1,0 +1,4 @@
+body{font-family:sans-serif;padding:1rem;background:#fff;color:#000}
+body.dark{background:#222;color:#eee}
+table{border-collapse:collapse;width:100%}
+th,td{border:1px solid #ccc;padding:0.5rem;text-align:left}


### PR DESCRIPTION
## Summary
- introduce shared aiohttp session and configurable autocomplete concurrency
- replace brute-force label generation with pruning generator
- use Jinja2 template for HTML output and add basic stylesheet
- switch TLD fetch and DNS checks to async libraries
- pin package versions and document supported Python version
- update tests for new async APIs and generator

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635fca46ec832a9b037ccc94e17fee