### PR TITLE
Refactor scoring and packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Running the script multiple times will append new findings to `results.jsonl`.
 The HTML file is updated periodically in the background and on graceful
 shutdown, so progress can be monitored while the scan is running.
 
+## Continuous integration
+
+A GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies
+and runs the test suite on every push or pull request.
+
 ## Running tests
 
 Install pytest and run the suite from the repository root:

--- a/domain_finder/__main__.py
+++ b/domain_finder/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "domain-finder"
+version = "0.1.0"
+description = "Utility for discovering available domains"
+authors = [{name = "Example", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "aiohttp==3.9.3",
+    "aiodns==3.0.0",
+    "pytrends==4.9.2",
+    "wordfreq==2.5.1",
+    "tqdm==4.66.2",
+    "jinja2==3.1.2",
+    "aiofiles==23.2.1"
+]
+
+[project.scripts]
+domain-finder = "domain_finder.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytrends==4.9.2
 wordfreq==2.5.1
 tqdm==4.66.2
 jinja2==3.1.2
+aiofiles==23.2.1

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -8,7 +8,7 @@ import time
 import asyncio
 from unittest.mock import Mock
 
-import domain
+import domain_finder as domain
 
 
 def test_is_pronounceable():

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,44 @@
+import numpy as np
+import domain_finder as domain
+
+
+def compute_scores(labels, tlds, stats, prices, cfg):
+    ngram_scores = np.array([stats[l]["ngram"] for l in labels])
+    volume_arr = np.array([stats[l]["volume"] for l in labels])
+    auto_arr = np.array([stats[l]["auto"] for l in labels])
+    length_scores = np.array([stats[l]["length_s"] for l in labels])
+    price_arr = np.array([prices[t] for t in tlds])
+
+    pn = (price_arr - price_arr.min()) / (price_arr.max() - price_arr.min() or 1)
+    nn = (ngram_scores - ngram_scores.min()) / (
+        ngram_scores.max() - ngram_scores.min() or 1
+    )
+    vn = (volume_arr - volume_arr.min()) / (volume_arr.max() - volume_arr.min() or 1)
+    an = (auto_arr - auto_arr.min()) / (auto_arr.max() - auto_arr.min() or 1)
+
+    scores = (
+        cfg.weight_length * length_scores[:, None]
+        + cfg.weight_price * pn[None, :]
+        + cfg.weight_ngram * nn[:, None]
+        + cfg.weight_volume * vn[:, None]
+        + cfg.weight_auto * an[:, None]
+    )
+    return scores
+
+
+def test_scoring_ranking():
+    cfg = domain.Config()
+    labels = ["aa", "bb"]
+    tlds = ["com", "net"]
+    stats = {
+        "aa": {"ngram": 1, "volume": 10, "auto": 5, "length_s": 1.0},
+        "bb": {"ngram": 0.5, "volume": 5, "auto": 2, "length_s": 0.5},
+    }
+    prices = {"com": 10, "net": 20}
+    scores = compute_scores(labels, tlds, stats, prices, cfg)
+    flat = scores.ravel()
+    best = flat.argmax()
+    li = best // len(tlds)
+    ti = best % len(tlds)
+    assert labels[li] == "aa"
+    assert tlds[ti] == "net"


### PR DESCRIPTION
## Summary
- move module into `domain_finder` package
- vectorise scoring and allow weight configuration
- generate labels with iterative BFS
- share aiodns resolver and persist negative results
- async file writes with aiofiles
- add pyproject and CI workflow
- add basic scoring test

## Testing
- `pip install -q -r requirements.txt aiofiles`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e0bba054832ab1b8b3622f390250