### PR TITLE
Fix pytrends retry error

### DIFF
--- a/domain_finder/__init__.py
+++ b/domain_finder/__init__.py
@@ -21,6 +21,18 @@ import contextlib
 import atexit
 import heapq
 import re
+import inspect
+from requests.packages.urllib3.util.retry import Retry as _Retry
+
+if "method_whitelist" not in inspect.signature(_Retry.__init__).parameters:
+    _orig_retry_init = _Retry.__init__
+
+    def _new_retry_init(self, *args, method_whitelist=None, **kwargs):
+        if method_whitelist is not None:
+            kwargs.setdefault("allowed_methods", method_whitelist)
+        _orig_retry_init(self, *args, **kwargs)
+
+    _Retry.__init__ = _new_retry_init
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- patch urllib3 Retry wrapper when method_whitelist is not supported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642e763ce8832ab63c24cd6be0c411