### PR TITLE
Remove Google Trends feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 Domain Finder is a Python utility that generates pronounceable short labels,
 combines them with popular top-level domains (TLDs), calculates a score based on
-search trends and other heuristics, and checks if the resulting domains are
+several heuristics, and checks if the resulting domains are
 available. Results are written both as an interactive HTML table and as a JSONL
 log for further processing.
 
 ## Prerequisites
 
 * Python 3.11
-* Network access to fetch TLD data and Google trends information
+* Network access to fetch TLD data
 
 Install required Python packages using:
 
@@ -60,7 +60,6 @@ Available options:
 - `--dns-batch-size` – number of concurrent DNS lookups per batch
 - `--queue-size` – how many top-scoring combinations to retain before scanning
 - `--flush-interval` – seconds between HTML updates
-- `--trends-concurrency` – max concurrent Google Trends requests
 - `--dns-timeout` – timeout for DNS queries in seconds
 - `--lang` – language code for word frequency scoring
 - `--tld-cache-refresh` – revalidate cached TLD list using IANA headers

--- a/domain_finder/cli.py
+++ b/domain_finder/cli.py
@@ -38,9 +38,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--queue-size", type=int, default=defaults.queue_size)
     parser.add_argument("--flush-interval", type=float, default=defaults.flush_interval)
     parser.add_argument(
-        "--trends-concurrency", type=int, default=defaults.trends_concurrency
-    )
-    parser.add_argument(
         "--autocomplete-concurrency",
         type=int,
         default=defaults.autocomplete_concurrency,
@@ -48,7 +45,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--weight-length", type=float, default=defaults.weight_length)
     parser.add_argument("--weight-price", type=float, default=defaults.weight_price)
     parser.add_argument("--weight-ngram", type=float, default=defaults.weight_ngram)
-    parser.add_argument("--weight-volume", type=float, default=defaults.weight_volume)
     parser.add_argument("--weight-auto", type=float, default=defaults.weight_auto)
     parser.add_argument("--lang", type=str, default=defaults.lang)
     parser.add_argument(
@@ -101,12 +97,10 @@ def main() -> None:
         dns_timeout=args.dns_timeout,
         queue_size=args.queue_size,
         flush_interval=args.flush_interval,
-        trends_concurrency=args.trends_concurrency,
         autocomplete_concurrency=args.autocomplete_concurrency,
         weight_length=args.weight_length,
         weight_price=args.weight_price,
         weight_ngram=args.weight_ngram,
-        weight_volume=args.weight_volume,
         weight_auto=args.weight_auto,
         lang=args.lang,
         resume_from=args.resume_from,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.11"
 dependencies = [
     "aiohttp==3.9.3",
     "aiodns==3.0.0",
-    "pytrends==4.9.2",
     "wordfreq==2.5.1",
     "tqdm==4.66.2",
     "jinja2==3.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiohttp==3.9.3
 aiodns==3.0.0
-pytrends==4.9.2
 wordfreq==2.5.1
 tqdm==4.66.2
 jinja2==3.1.2

--- a/templates/template.html
+++ b/templates/template.html
@@ -22,7 +22,6 @@
         <th scope="col" aria-sort="none">Score</th>
         <th scope="col" aria-sort="none">Price</th>
         <th scope="col" aria-sort="none">n-gram</th>
-        <th scope="col" aria-sort="none">Volume</th>
         <th scope="col" aria-sort="none">Auto</th>
       </tr>
     </thead>
@@ -34,7 +33,6 @@
         <td>{{ r.score|default(0) }}</td>
         <td>{{ r.price }}</td>
         <td>{{ '%.2f' % r.ngram }}</td>
-        <td>{{ r.volume }}</td>
         <td>{{ r.auto }}</td>
       </tr>
     {% endfor %}

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -115,23 +115,6 @@ def test_fetch_tlds_cache_expired(tmp_path):
     assert tlds == ["com"]
 
 
-def test_search_volume_cache(monkeypatch):
-    async def fake_sv(label, session, retries=3):
-        return 42
-
-    monkeypatch.setattr(domain, "search_volume", fake_sv)
-    cache = {}
-    res = asyncio.run(domain.gather_search_volumes(["abc"], cache, session=object()))
-    assert res == {"abc": 42}
-    assert cache["abc"]["volume"] == 42
-
-    async def fail_sv(label, session, retries=3):
-        raise AssertionError("called")
-
-    monkeypatch.setattr(domain, "search_volume", fail_sv)
-    res2 = asyncio.run(domain.gather_search_volumes(["abc"], cache, session=object()))
-    assert res2 == {"abc": 42}
-
 
 def test_autocomplete_cache(monkeypatch):
     async def fake_ac(label, session, retries=3):

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -4,7 +4,6 @@ import domain_finder as domain
 
 def compute_scores(labels, tlds, stats, prices, cfg):
     ngram_scores = np.array([stats[label]["ngram"] for label in labels])
-    volume_arr = np.array([stats[label]["volume"] for label in labels])
     auto_arr = np.array([stats[label]["auto"] for label in labels])
     length_scores = np.array([stats[label]["length_s"] for label in labels])
     price_arr = np.array([prices[t] for t in tlds])
@@ -13,14 +12,12 @@ def compute_scores(labels, tlds, stats, prices, cfg):
     nn = (ngram_scores - ngram_scores.min()) / (
         ngram_scores.max() - ngram_scores.min() or 1
     )
-    vn = (volume_arr - volume_arr.min()) / (volume_arr.max() - volume_arr.min() or 1)
     an = (auto_arr - auto_arr.min()) / (auto_arr.max() - auto_arr.min() or 1)
 
     scores = (
         cfg.weight_length * length_scores[:, None]
         + cfg.weight_price * pn[None, :]
         + cfg.weight_ngram * nn[:, None]
-        + cfg.weight_volume * vn[:, None]
         + cfg.weight_auto * an[:, None]
     )
     return scores


### PR DESCRIPTION
## Summary
- drop Google Trends scoring and related CLI options
- remove pytrends dependency
- clean up template and docs
- update tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pip install numpy`
- `pip install beautifulsoup4`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864308734f4832ab982f38e92ce1bdd