### PR TITLE
Fix Candidate comparison for heap

### DIFF
--- a/domain_finder/__init__.py
+++ b/domain_finder/__init__.py
@@ -98,6 +98,10 @@ class Candidate:
             s += f" ({self.score:.4f})"
         return s
 
+    def __lt__(self, other: "Candidate") -> bool:
+        """Provide a deterministic ordering for heap operations."""
+        return self.idx < other.idx
+
 
 def candidate_to_dict(c: "Candidate") -> dict:
     """Convert a ``Candidate`` to a serializable dictionary."""


### PR DESCRIPTION
## Summary
- provide `Candidate.__lt__` for deterministic comparison in heap operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864367d1638832aa0ee2df49721e4bb