### PR TITLE
Fix aiodns timeout call

### DIFF
--- a/domain_finder/__init__.py
+++ b/domain_finder/__init__.py
@@ -825,6 +825,7 @@ async def dns_available(
 
     Args:
         domain: Full domain to query.
+        timeout: Optional resolver timeout in seconds.
 
     Returns:
         True if no DNS record was found.
@@ -832,7 +833,7 @@ async def dns_available(
     if resolver is None:
         resolver = aiodns.DNSResolver(timeout=timeout)
     try:
-        await resolver.gethostbyname(domain, socket.AF_INET, timeout=timeout)
+        await resolver.gethostbyname(domain, socket.AF_INET)
         return False
     except aiodns.error.DNSError:
         return True


### PR DESCRIPTION
## Summary
- update `dns_available` to match aiodns 3.0 API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643db8faf0832aa2009793811e41b3